### PR TITLE
fix(auth): sync Limen session token into Bearer store

### DIFF
--- a/src/lib/limen-auth.ts
+++ b/src/lib/limen-auth.ts
@@ -28,6 +28,10 @@ export const authClient = createAuthClient<typeof plugins, UserFields>({
   parseSession: (raw) => {
     const body = raw as { user?: Record<string, unknown>; token?: string };
     const u = (body.user ?? raw) as Record<string, unknown>;
+    const token =
+      typeof body.token === "string" && body.token.trim() !== ""
+        ? body.token.trim()
+        : undefined;
     return {
       user: {
         id: String(u.id ?? ""),
@@ -46,6 +50,8 @@ export const authClient = createAuthClient<typeof plugins, UserFields>({
           (u.lastName as string | null | undefined) ??
           null,
       },
+      // Exposed so AuthProvider can sync Bearer for Go APIs (cookie is HttpOnly).
+      ...(token ? { token } : {}),
     };
   },
 });

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -57,8 +57,10 @@ export function AuthProvider({
       if (session?.user) {
         const sessionUser = userFromLimen(session.user);
         setUser(sessionUser);
-        const token = authClient.bearer.getTokens()?.accessToken;
-        if (token) setToken(token);
+        const sessionToken =
+          (session as { token?: string }).token ??
+          authClient.bearer.getTokens()?.accessToken;
+        if (sessionToken) setToken(sessionToken);
         await runPostAuthClaims(sessionUser.id);
         setLoading(false);
         return;
@@ -92,8 +94,10 @@ export function AuthProvider({
     const sessionUser = data?.user ?? (await authClient.getSession())?.user;
     if (!sessionUser) throw new Error("Login failed");
     setUser(userFromLimen(sessionUser));
-    const token = authClient.bearer.getTokens()?.accessToken;
-    if (token) setToken(token);
+    const sessionToken =
+      (data as { token?: string } | null | undefined)?.token ??
+      authClient.bearer.getTokens()?.accessToken;
+    if (sessionToken) setToken(sessionToken);
     await runPostAuthClaims(userFromLimen(sessionUser).id);
   };
 


### PR DESCRIPTION
## Summary
- `parseSession` preserves `token` from Limen session payload
- AuthProvider sets Bearer from session token when present

## Test plan
- [ ] Login / refresh → learn APIs send Authorization when token present
- [ ] Works with backend cookie-fallback even if Bearer missing