### PR TITLE
fix(learn): align trial API client with snake_case JSON fields

### DIFF
--- a/src/components/learn/TrialLessonPlayer.tsx
+++ b/src/components/learn/TrialLessonPlayer.tsx
@@ -28,6 +28,15 @@ interface MatchPrompt {
   pairs?: [string, string][];
 }
 
+function parsePromptJson<T>(raw: string | undefined | null): T {
+  if (!raw) return {} as T;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 interface TrialLessonPlayerProps {
   lessonId: string;
 }
@@ -63,7 +72,7 @@ export function TrialLessonPlayer({ lessonId }: TrialLessonPlayerProps) {
       ]);
       setLesson(l);
       setExercises(exs);
-      setAttemptId(start.attemptId);
+      setAttemptId(start.attempt_id);
     } catch (err) {
       setError(err instanceof Error ? err.message : t("loadError"));
     } finally {
@@ -121,7 +130,7 @@ export function TrialLessonPlayer({ lessonId }: TrialLessonPlayerProps) {
     try {
       const result = await completeLesson(lesson.id);
       markLessonCompleted(lesson.id);
-      if (result.unitCompleted) {
+      if (result.unit_completed) {
         setUnitCompleted(true);
       }
       router.push("/learn");
@@ -141,7 +150,7 @@ export function TrialLessonPlayer({ lessonId }: TrialLessonPlayerProps) {
       setStep((s) => s + 1);
       const next = exercises[step + 1];
       if (next?.type === "match") {
-        const prompt = JSON.parse(next.promptJson) as MatchPrompt;
+        const prompt = parsePromptJson<MatchPrompt>(next.prompt_json);
         setMatchPairs(prompt.pairs ?? []);
       }
     }
@@ -149,7 +158,7 @@ export function TrialLessonPlayer({ lessonId }: TrialLessonPlayerProps) {
 
   useEffect(() => {
     if (current?.type === "match") {
-      const prompt = JSON.parse(current.promptJson) as MatchPrompt;
+      const prompt = parsePromptJson<MatchPrompt>(current.prompt_json);
       setMatchPairs(prompt.pairs ?? []);
     }
   }, [current]);
@@ -177,7 +186,7 @@ export function TrialLessonPlayer({ lessonId }: TrialLessonPlayerProps) {
 
   if (!current || !lesson) return null;
 
-  const selectPrompt = JSON.parse(current.promptJson) as SelectPrompt;
+  const selectPrompt = parsePromptJson<SelectPrompt>(current.prompt_json);
 
   return (
     <div className="max-w-lg mx-auto p-6 space-y-6">

--- a/src/lib/learn-api.ts
+++ b/src/lib/learn-api.ts
@@ -11,17 +11,17 @@ export const TRIAL_UNIT_ID =
 
 export interface LearnUnit {
   id: string;
-  courseId: string;
+  course_id: string;
   position: number;
   title: string;
 }
 
 export interface LearnLesson {
   id: string;
-  skillId: string;
+  skill_id: string;
   position: number;
   title: string;
-  xpReward: number;
+  xp_reward: number;
   required: boolean;
   /** Present when the API includes owner progress for this lesson. */
   status?: "not_started" | "in_progress" | "completed";
@@ -29,7 +29,7 @@ export interface LearnLesson {
 
 export interface LearnSkill {
   id: string;
-  unitId: string;
+  unit_id: string;
   position: number;
   title: string;
   lessons: LearnLesson[];
@@ -37,23 +37,23 @@ export interface LearnSkill {
 
 export interface LearnExercise {
   id: string;
-  lessonId: string;
+  lesson_id: string;
   position: number;
   type: string;
-  promptJson: string;
+  prompt_json: string;
 }
 
 export interface GuestSession {
-  guestId: string;
+  guest_id: string;
 }
 
 export interface ClaimGuestResponse {
-  lessonsMerged: number;
+  lessons_merged: number;
 }
 
 export interface CompleteLessonResponse {
   xp: number;
-  unitCompleted: boolean;
+  unit_completed: boolean;
 }
 
 async function learnRequest<T>(
@@ -99,7 +99,7 @@ export interface TrialUnitResponse {
   unit: LearnUnit;
   skills: LearnSkill[];
   /** Owner unit progress when returned by learn-service. */
-  unitStatus?: "not_started" | "in_progress" | "completed";
+  unit_status?: "not_started" | "in_progress" | "completed";
 }
 
 export async function getTrialUnit(
@@ -116,7 +116,7 @@ export async function getLesson(
 
 export async function startLesson(
   lessonId: string,
-): Promise<{ attemptId: string }> {
+): Promise<{ attempt_id: string }> {
   return learnRequest(`/v1/learn/lessons/${lessonId}/start`, {
     method: "POST",
     body: JSON.stringify({ id: lessonId }),
@@ -131,9 +131,9 @@ export async function submitAnswer(
   return learnRequest(`/v1/learn/attempts/${attemptId}/answer`, {
     method: "POST",
     body: JSON.stringify({
-      attemptId,
-      exerciseId,
-      payloadJson: JSON.stringify(payload),
+      attempt_id: attemptId,
+      exercise_id: exerciseId,
+      payload_json: JSON.stringify(payload),
     }),
   });
 }

--- a/src/lib/trial-progress.ts
+++ b/src/lib/trial-progress.ts
@@ -10,7 +10,7 @@ export interface UnitProgressSnapshot {
 /** Derive progress from GET /v1/learn/units/{id} when lesson/unit status fields are present. */
 export function progressFromUnit(data: {
   skills: LearnSkill[];
-  unitStatus?: string;
+  unit_status?: string;
 }): UnitProgressSnapshot {
   const completedLessonIds = data.skills
     .flatMap((skill) => skill.lessons)
@@ -19,6 +19,6 @@ export function progressFromUnit(data: {
 
   return {
     completedLessonIds,
-    unitCompleted: data.unitStatus === "completed",
+    unitCompleted: data.unit_status === "completed",
   };
 }


### PR DESCRIPTION
## Summary
- Learn-service returns snake_case (`prompt_json`, `attempt_id`, `unit_status`, …) but the frontend expected camelCase, causing `JSON.parse(undefined)` → undefined is not valid JSON` on trial lesson pages.
- Align `learn-api` types/requests and trial player/progress readers with the live API wire format; parse prompts safely when missing/invalid.

## Test plan
- [ ] Open `/en/lesson/trial/33333333-3333-3333-3333-333333333331` as guest — page loads without console SyntaxError
- [ ] Select an answer and submit — feedback works
- [ ] Complete lesson and return to `/learn` — progress updates
- [ ] Soft-gate / unit completed still hydrates from `unit_status` when present
