### PR TITLE
fix(learn): sync views ref in effect for region mask hit-test

### DIFF
--- a/src/components/learn/journey/useRegionMaskHitTest.ts
+++ b/src/components/learn/journey/useRegionMaskHitTest.ts
@@ -23,7 +23,10 @@ export function useRegionMaskHitTest(
   const [mask, setMask] = useState<RegionMaskData | null>(null);
   const maskRef = useRef<RegionMaskData | null>(null);
   const viewsRef = useRef(views);
-  viewsRef.current = views;
+
+  useEffect(() => {
+    viewsRef.current = views;
+  }, [views]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
Satisfies react-hooks/refs by avoiding ref updates during render.